### PR TITLE
Ekapner ki sandbox refresh

### DIFF
--- a/KNOWNISSUES.md
+++ b/KNOWNISSUES.md
@@ -3,7 +3,7 @@
 ## Source Tracking Lost After a Connected Sandbox Is Refreshed
 
 ### Issue
-If you refresh a sandbox used in an active DevOps Center project, source tracking is lost and DevOps Center can't identify changed files. 
+If you refresh a sandbox used in an active DevOps Center project pipeline, source tracking is lost and DevOps Center can't identify changed files. 
 
 ### Workaround
 If you don't have access to the Setup menu, ask your Salesforce admin for help.


### PR DESCRIPTION
Added a Known Issue for resetting source tracking if a dev sandbox is refreshed. 